### PR TITLE
triggers.py 의 실시간데이터 수신 부분 디자인패턴 개선

### DIFF
--- a/res/DB/market_data.py
+++ b/res/DB/market_data.py
@@ -9,7 +9,7 @@ from .db import KRXRealData
 from .db import KRXNewsData
 from .db import KRXIndexData
 import pandas as pd
-import multiprocessing
+from multiprocessing import Process
 import threading
 import datetime
 import time
@@ -17,37 +17,42 @@ import pythoncom
 import win32com.client
 
 # 로그인
-def login():
+class Login:
     """
-    실서버 로그인
+    이베스트증권 api 서버 로그인을 위한 클래스
+    """
+    def __init__(self):
+        self.file_path = "./xing_user2.json"
 
-    {"user_id" : "이베스트증권 ID",
-    "user_pw" : "이베스트증권 비밀번호",
-    "mock_pw" : "모의투자 비밀번호",
-    "cert_pw" : "공인인증서 비밀번호"}
-    형식의 ./xing_user2.json 파일을 읽어 api 로그인
-    """
-    file_path = "./xing_user2.json"
-    with open(file_path, "r") as json_file:
-        user = json.load(json_file)
-    session = XASession()
-    session.login(user)
+    def login(self):
+        """
+        실서버 로그인
 
-def login_mock():
-    """
-    모의투자서버 로그인
+        {"user_id" : "이베스트증권 ID",
+        "user_pw" : "이베스트증권 비밀번호",
+        "mock_pw" : "모의투자 비밀번호",
+        "cert_pw" : "공인인증서 비밀번호"}
+        형식의 ./xing_user2.json 파일을 읽어 api 로그인
+        """
+        with open(self.file_path, "r") as json_file:
+            user = json.load(json_file)
+        session = XASession()
+        session.login(user)
 
-    {"user_id" : "이베스트증권 ID",
-    "user_pw" : "이베스트증권 비밀번호",
-    "mock_pw" : "모의투자 비밀번호",
-    "cert_pw" : "공인인증서 비밀번호"}
-    형식의 ./xing_user2.json 파일을 읽어 api 서버로 로그인
-    """
-    file_path = "./xing_user2.json"
-    with open(file_path, "r") as json_file:
-        user = json.load(json_file)
-    session = XASession()
-    session.login(user, server_type=1)
+    def login_mock(self):
+        """
+        모의투자서버 로그인
+
+        {"user_id" : "이베스트증권 ID",
+        "user_pw" : "이베스트증권 비밀번호",
+        "mock_pw" : "모의투자 비밀번호",
+        "cert_pw" : "공인인증서 비밀번호"}
+        형식의 ./xing_user2.json 파일을 읽어 api 서버로 로그인
+        """
+        with open(self.file_path, "r") as json_file:
+            user = json.load(json_file)
+        session = XASession()
+        session.login(user, server_type=1)
 
 
 # 실시간 체결가 수신 전용 이벤트 핸들러
@@ -102,97 +107,100 @@ class IndexEvent(EventHandler):
         KRXIndexData().update(result)
 
 
+class TRData:
+    def shcode(self, market_type):
+        """
+        시장 구분별 종목코드를 모두 읽는다
 
-def _shcode(market_type):
-    """
-    시장 구분별 종목코드를 모두 읽는다
+        Args:
+            market_type: 0 전체
+                         1 코스피
+                         2 코스닥
+        Return:
+            'list' of shcode
+        """
+        market_type = str(market_type)
+        query = XAQuery()
+        in_field = {"gubun": market_type}
+        query.set_inblock('t8430', in_field)
+        query.request()
+        out_count = query.get_count('t8430OutBlock')
+        result = [query.get_outblock('t8430OutBlock', "shcode", i)["shcode"] for i in range(out_count)]
+        return result
 
-    Args:
-        market_type: 0 전체
-                     1 코스피
-                     2 코스닥
-    Return:
-        'list' of shcode
-    """
-    market_type = str(market_type)
-    query = XAQuery()
-    in_field = {"gubun": market_type}
-    query.set_inblock('t8430', in_field)
-    query.request()
-    out_count = query.get_count('t8430OutBlock')
-    result = [query.get_outblock('t8430OutBlock', "shcode", i)["shcode"] for i in range(out_count)]
-    return result
+    def index_code(self):
+        """
+        업종코드 정보를 읽는다
 
-def _index_code():
-    """
-    업종코드 정보를 읽는다
+        Return:
+            'list' of upcode(업종코드)
+            001: 코스피
+            301: 코스닥
+        """
+        query = XAQuery()
+        in_field = {"gubun1": ''}
+        query.set_inblock('t8424', in_field)
+        query.request()
+        out_count = query.get_count('t8424OutBlock')
+        result = [query.get_outblock('t8424OutBlock', "upcode", i)["upcode"] for i in range(out_count)]
+        return result
 
-    Return:
-        'list' of upcode(업종코드)
-        001: 코스피
-        301: 코스닥
-    """
-    query = XAQuery()
-    in_field = {"gubun1": ''}
-    query.set_inblock('t8424', in_field)
-    query.request()
-    out_count = query.get_count('t8424OutBlock')
-    result = [query.get_outblock('t8424OutBlock', "upcode", i)["upcode"] for i in range(out_count)]
-    return result
+class Kospi(Process):
+    def run(self):
+        """
+        KOSPI 모든종목 실시간 감시
+        종목코드, 체결시간, 전일대비구분, 전일대비, 등락율, 현재가, 시가, 고가, 저가, 누적거래량, 누적거래대금
+        실시간 감시, db에 업데이트
+        """
+        Login().login()
+        kospi = TRData().shcode(1)
+        kospi_data = XAReal(MarketEvent)
+        kospi_data.set_inblock("S3_", kospi)
+        kospi_data.set_outblock(["shcode", "chetime", "sign", "change", "drate", "price", "open", "high", "low", "volume", "value"])
+        kospi_data.start()
 
+class Kosdaq(Process):
+    def run(self):
+        """
+        KOSDAQ 모든종목 실시간 감시
+        종목코드, 체결시간, 전일대비구분, 전일대비, 등락율, 현재가, 시가, 고가, 저가, 누적거래량, 누적거래대금
+        실시간 감시, db에 업데이트
+        """
+        Login().login()
+        kosdaq = TRData().shcode(2)
+        kosdaq_data = XAReal(MarketEvent)
+        kosdaq_data.set_inblock("K3_", kosdaq)
+        kosdaq_data.set_outblock(["shcode", "chetime", "sign", "change", "drate", "price", "open", "high", "low", "volume", "value"])
+        kosdaq_data.start()
 
-def kospi_tickdata():
-    """
-    KOSPI 모든종목 실시간 감시
-    종목코드, 체결시간, 전일대비구분, 전일대비, 등락율, 현재가, 시가, 고가, 저가, 누적거래량, 누적거래대금
-    실시간 감시, db에 업데이트
-    """
-    login()
-    kospi = _shcode(1)
-    kospi_data = XAReal(MarketEvent)
-    kospi_data.set_inblock("S3_", kospi)
-    kospi_data.set_outblock(["shcode", "chetime", "sign", "change", "drate", "price", "open", "high", "low", "volume", "value"])
-    kospi_data.start()
+class KrIndex(Process):
+    def run(self):
+        """
+        업종별 지수
+        (일단 코스피, 코스닥 지수만)
+        업종코드, 시간, 전일대비구분, 전일대비, 등락율, 현재지수, 시가지수, 고가지수, 저가지수, 상한종목수, 하한종목수, 상승종목비율, 외인순매수금액, 기관순매수금액
 
-def kosdaq_tickdata():
-    """
-    KOSDAQ 모든종목 실시간 감시
-    종목코드, 체결시간, 전일대비구분, 전일대비, 등락율, 현재가, 시가, 고가, 저가, 누적거래량, 누적거래대금
-    실시간 감시, db에 업데이트
-    """
-    login()
-    kosdaq = _shcode(2)
-    kosdaq_data = XAReal(MarketEvent)
-    kosdaq_data.set_inblock("K3_", kosdaq)
-    kosdaq_data.set_outblock(["shcode", "chetime", "sign", "change", "drate", "price", "open", "high", "low", "volume", "value"])
-    kosdaq_data.start()
+        실시간 감시, db에 업데이트
+        {'upcode': '001', 'time': '153210', 'sign': '2', 'change': '4.29', 'drate': '0.13', 'jisu': '3198.62', 'openjisu': '3194.08', 'highjisu': '3206.76', 'lowjisu': '3185.67', 'upjo': '5', 'downjo': '0', 'upjrate': '57.48', 'frgsvalue': '-213424', 'orgsvalue': '-479101'}
+        """
+        Login().login_mock()
+        # index = _index_code()
+        index_data = XAReal(IndexEvent)
+        # index_data.set_inblock("IJ_", index, field = "upcode")
+        index_data.set_inblock("IJ_", ['001', '301'], field="upcode")
+        index_data.set_outblock(["upcode", "time", "sign", "change", "drate", "jisu", "openjisu", "highjisu", "lowjisu", "upjo", "downjo", "upjrate", "frgsvalue", "orgsvalue"])
+        index_data.start()
 
-def index_tickdata():
-    """
-    업종별 지수
-    (일단 코스피, 코스닥 지수만)
-    업종코드, 시간, 전일대비구분, 전일대비, 등락율, 현재지수, 시가지수, 고가지수, 저가지수, 상한종목수, 하한종목수, 상승종목비율, 외인순매수금액, 기관순매수금액
-
-    실시간 감시, db에 업데이트
-    {'upcode': '001', 'time': '153210', 'sign': '2', 'change': '4.29', 'drate': '0.13', 'jisu': '3198.62', 'openjisu': '3194.08', 'highjisu': '3206.76', 'lowjisu': '3185.67', 'upjo': '5', 'downjo': '0', 'upjrate': '57.48', 'frgsvalue': '-213424', 'orgsvalue': '-479101'}
-    """
-    login_mock()
-    # index = _index_code()
-    index_data = XAReal(IndexEvent)
-    # index_data.set_inblock("IJ_", index, field = "upcode")
-    index_data.set_inblock("IJ_", ['001', '301'], field="upcode")
-    index_data.set_outblock(["upcode", "time", "sign", "change", "drate", "jisu", "openjisu", "highjisu", "lowjisu", "upjo", "downjo", "upjrate", "frgsvalue", "orgsvalue"])
-    index_data.start()
-
-def news():
-    """
-    실시간 뉴스데이터 수신
-    """
-    login()
-    news = XAReal(NewsEvent)
-    news.set_inblock("NWS", "NWS001", field = "nwcode")
-    news.set_outblock(["id", "title", "code"])
-    news.start()
+class News(Process):
+    def run(self):
+        """
+        실시간 뉴스데이터 수신
+        """
+        Login().login()
+        news = XAReal(NewsEvent)
+        news.set_inblock("NWS", "NWS001", field = "nwcode")
+        news.set_outblock(["id", "title", "code"])
+        news.start()
 
 # 테스트용
 def main():
@@ -200,17 +208,25 @@ def main():
     작동 테스트용 함수
     """
     if __name__ == "__main__":
-        login()
+        Login().login()
         # StockInfoTable().update_table()
-        process_kospi = multiprocessing.Process(target = kospi_tickdata)
-        process_kosdaq = multiprocessing.Process(target = kosdaq_tickdata)
-        process_index = multiprocessing.Process(target = index_tickdata)
+        process_kospi = Kospi()
+        process_kosdaq = Kosdaq()
+        process_index = KrIndex()
         # process_news = multiprocessing.Process(target = news)
         process_kospi.start()
         time.sleep(3)
         process_kosdaq.start()
         time.sleep(3)
         process_index.start()
+        # time.sleep(15)
+        # process_kospi.terminate()
+        # print("kospi terminate")
+        # process_kospi.close()
+
+        # process_kosdaq.terminate()
+        # print("kospi terminate")
+        # process_kosdaq.close()
         # process_news.start()
 
 main()


### PR DESCRIPTION
우선 기존 market_data.py 의 구조를 전부 바꿨음. 특히 tickdata 수신 부분을 함수로 정의한 기존 방식에서 multiprocessing.Process 클래스를 상속받고 run 메서드를 오버라이딩 하는 방식으로 수정하였음

[https://youtu.be/q3_WXP9pPUQ](https://youtu.be/q3_WXP9pPUQ)
또한 이 영상을 보고 깊게 감명을 받아 mediator 패턴으로 triggers.py 와 market_data.py의 결합성을 낮추려고 했다.
그런데 완성하고 나니까 저 패턴을 굳이 안쓰고도 결합도를 낮출 방법이 있더라.
하지만 여기저기서 쓰일수 있는 패턴 같아서 나중에 참고할 수 있도록 그냥 넣었다.

다만 걸리는점은 현재 환경문제때문에 전체 파일을 구동할 수가 없어서 이게 실제로 되는지는 테스트하지 못한 상태다.
market_data.py 부분만 따로 구동하였을때는 문제가 없었지만 바꾼 디자인 패턴에서 전체 프로그램이 잘 돌아가는지는 미지수임
